### PR TITLE
Split launch files and add gazebo_helm node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,33 @@
 cmake_minimum_required(VERSION 3.8)
 project(ben_gazebo)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(control_toolbox REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(marine_interfaces REQUIRED)
+
+add_executable(gazebo_helm src/gazebo_helm_node.cpp)
+ament_target_dependencies(gazebo_helm
+  rclcpp
+  rclcpp_lifecycle
+  control_toolbox
+  geometry_msgs
+  nav_msgs
+  std_msgs
+  marine_interfaces
+)
+
+install(TARGETS gazebo_helm
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 install(DIRECTORY
   urdf

--- a/launch/gazebo_launch.py
+++ b/launch/gazebo_launch.py
@@ -1,4 +1,9 @@
-"""Launch Gz Harmonic simulation with BEN spawned in an ocean world."""
+"""Launch Gz Harmonic simulation with BEN spawned in an ocean world.
+
+Thin wrapper: starts Gazebo with ocean.sdf, then includes spawn_ben_launch.py.
+For spawning BEN into an externally launched world, use spawn_ben_launch.py
+directly with the appropriate world_name argument.
+"""
 
 import os
 
@@ -7,9 +12,8 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import Command, LaunchConfiguration
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -41,13 +45,6 @@ def generate_launch_description():
     declare_P = DeclareLaunchArgument('P', default_value='0')
     declare_Y = DeclareLaunchArgument('Y', default_value='0')
 
-    # Process xacro
-    xacro_file = os.path.join(pkg_ben_gazebo, 'urdf', 'ben.xacro')
-    robot_description = ParameterValue(
-        Command(['xacro ', xacro_file, ' namespace:=', namespace]),
-        value_type=str,
-    )
-
     # Start Gz sim
     gz_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -62,148 +59,16 @@ def generate_launch_description():
         }.items(),
     )
 
-    # Robot state publisher (publishes TF from URDF)
-    robot_state_publisher = Node(
-        package='robot_state_publisher',
-        executable='robot_state_publisher',
-        namespace=namespace,
-        parameters=[{
-            'robot_description': robot_description,
-            'use_sim_time': True,
-        }],
-        output='screen',
-    )
-
-    # Spawn model into Gz from the robot_description topic
-    spawn_entity = Node(
-        package='ros_gz_sim',
-        executable='create',
-        arguments=[
-            '-name', namespace,
-            '-topic', [namespace, '/robot_description'],
-            '-x', x, '-y', y, '-z', z,
-            '-R', R, '-P', P, '-Y', Y,
-        ],
-        output='screen',
-    )
-
-    # ros_gz_bridge for all sensor and thruster topics
-    bridge_args = [
-        # Clock
-        '/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock',
-        # GPS NavSat
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace, '/gps/sensor/', namespace,
-         '_gps_navsat/navsat'
-         '@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat'],
-        # Heading IMU
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace, '/heading/sensor/', namespace,
-         '_heading_imu/imu'
-         '@sensor_msgs/msg/Imu[gz.msgs.IMU'],
-        # POS MV NavSat
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace, '/motion_sensor/sensor/', namespace,
-         '_posmv_navsat/navsat'
-         '@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat'],
-        # POS MV IMU
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace, '/motion_sensor/sensor/', namespace,
-         '_posmv_imu/imu'
-         '@sensor_msgs/msg/Imu[gz.msgs.IMU'],
-        # Lidar point cloud
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace, '/lidar/sensor/lidar_sensor/scan/points'
-         '@sensor_msgs/msg/PointCloud2[gz.msgs.PointCloudPacked'],
-        # Forward camera image
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace,
-         '/forward_camera/sensor/forward_camera_sensor/image'
-         '@sensor_msgs/msg/Image[gz.msgs.Image'],
-        # Forward camera info
-        ['/world/ocean/model/', namespace,
-         '/link/', namespace,
-         '/forward_camera/sensor/forward_camera_sensor/camera_info'
-         '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
-        # Thruster command (ROS → Gz)
-        ['/', namespace, '/thrusters/main/thrust'
-         '@std_msgs/msg/Float64]gz.msgs.Double'],
-        # Steering command (ROS → Gz)
-        ['/', namespace, '/thrusters/main/pos'
-         '@std_msgs/msg/Float64]gz.msgs.Double'],
-        # MBES ram position command (ROS → Gz)
-        ['/', namespace, '/mbes/ram/pos'
-         '@std_msgs/msg/Float64]gz.msgs.Double'],
-    ]
-
-    # Add panoramic cameras (6 cameras, image + camera_info each)
-    for i in range(1, 7):
-        bridge_args.extend([
-            ['/world/ocean/model/', namespace,
-             '/link/', namespace,
-             f'/pano_{i}/sensor/pano_{i}_sensor/image'
-             '@sensor_msgs/msg/Image[gz.msgs.Image'],
-            ['/world/ocean/model/', namespace,
-             '/link/', namespace,
-             f'/pano_{i}/sensor/pano_{i}_sensor/camera_info'
-             '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
-        ])
-
-    bridge = Node(
-        package='ros_gz_bridge',
-        executable='parameter_bridge',
-        arguments=bridge_args,
-        remappings=[
-            # GPS
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace, '/gps/sensor/', namespace,
-              '_gps_navsat/navsat'],
-             [namespace, '/sensors/gps/fix']),
-            # Heading
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace, '/heading/sensor/', namespace,
-              '_heading_imu/imu'],
-             [namespace, '/sensors/heading/data']),
-            # POS MV NavSat
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace, '/motion_sensor/sensor/', namespace,
-              '_posmv_navsat/navsat'],
-             [namespace, '/sensors/posmv/fix']),
-            # POS MV IMU
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace, '/motion_sensor/sensor/', namespace,
-              '_posmv_imu/imu'],
-             [namespace, '/sensors/posmv/imu/data']),
-            # Lidar
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace,
-              '/lidar/sensor/lidar_sensor/scan/points'],
-             [namespace, '/sensors/lidar/points']),
-            # Forward camera
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace,
-              '/forward_camera/sensor/forward_camera_sensor/image'],
-             [namespace, '/sensors/cameras/forward_camera/image_raw']),
-            (['/world/ocean/model/', namespace,
-              '/link/', namespace,
-              '/forward_camera/sensor/forward_camera_sensor/camera_info'],
-             [namespace, '/sensors/cameras/forward_camera/camera_info']),
-        ] + [
-            remap
-            for i in range(1, 7)
-            for remap in [
-                (['/world/ocean/model/', namespace,
-                  '/link/', namespace,
-                  f'/pano_{i}/sensor/pano_{i}_sensor/image'],
-                 [namespace, f'/sensors/cameras/pano_{i}/image_raw']),
-                (['/world/ocean/model/', namespace,
-                  '/link/', namespace,
-                  f'/pano_{i}/sensor/pano_{i}_sensor/camera_info'],
-                 [namespace, f'/sensors/cameras/pano_{i}/camera_info']),
-            ]
-        ],
-        parameters=[{'use_sim_time': True}],
-        output='screen',
+    # Spawn BEN (robot_state_publisher + entity spawner + bridge)
+    spawn_ben = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_ben_gazebo, 'launch', 'spawn_ben_launch.py')),
+        launch_arguments={
+            'namespace': namespace,
+            'world_name': 'ocean',
+            'x': x, 'y': y, 'z': z,
+            'R': R, 'P': P, 'Y': Y,
+        }.items(),
     )
 
     # RViz (optional)
@@ -222,8 +87,6 @@ def generate_launch_description():
         declare_x, declare_y, declare_z,
         declare_R, declare_P, declare_Y,
         gz_sim,
-        robot_state_publisher,
-        spawn_entity,
-        bridge,
+        spawn_ben,
         rviz_node,
     ])

--- a/launch/spawn_ben_launch.py
+++ b/launch/spawn_ben_launch.py
@@ -1,0 +1,198 @@
+"""Spawn BEN into an already-running Gazebo world."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import Command, LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    pkg_ben_gazebo = get_package_share_directory('ben_gazebo')
+
+    # Launch arguments
+    namespace = LaunchConfiguration('namespace')
+    world_name = LaunchConfiguration('world_name')
+    x = LaunchConfiguration('x')
+    y = LaunchConfiguration('y')
+    z = LaunchConfiguration('z')
+    R = LaunchConfiguration('R')
+    P = LaunchConfiguration('P')
+    Y = LaunchConfiguration('Y')
+
+    declare_namespace = DeclareLaunchArgument(
+        'namespace', default_value='ben')
+    declare_world_name = DeclareLaunchArgument(
+        'world_name', default_value='ocean',
+        description='Gz world name (used in bridge topic paths)')
+    declare_x = DeclareLaunchArgument('x', default_value='0')
+    declare_y = DeclareLaunchArgument('y', default_value='0')
+    declare_z = DeclareLaunchArgument('z', default_value='0.17')
+    declare_R = DeclareLaunchArgument('R', default_value='0')
+    declare_P = DeclareLaunchArgument('P', default_value='0')
+    declare_Y = DeclareLaunchArgument('Y', default_value='0')
+
+    # Process xacro
+    xacro_file = os.path.join(pkg_ben_gazebo, 'urdf', 'ben.xacro')
+    robot_description = ParameterValue(
+        Command(['xacro ', xacro_file, ' namespace:=', namespace]),
+        value_type=str,
+    )
+
+    # Robot state publisher (publishes TF from Gazebo URDF with sensors/plugins)
+    robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        namespace=namespace,
+        parameters=[{
+            'robot_description': robot_description,
+            'use_sim_time': True,
+        }],
+        output='screen',
+    )
+
+    # Spawn model into Gz from the robot_description topic
+    spawn_entity = Node(
+        package='ros_gz_sim',
+        executable='create',
+        arguments=[
+            '-name', namespace,
+            '-topic', [namespace, '/robot_description'],
+            '-x', x, '-y', y, '-z', z,
+            '-R', R, '-P', P, '-Y', Y,
+        ],
+        output='screen',
+    )
+
+    # ros_gz_bridge for all sensor and thruster topics
+    # world_name is used in Gz topic paths instead of hardcoded 'ocean'
+    bridge_args = [
+        # Clock
+        '/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock',
+        # GPS NavSat
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace, '/gps/sensor/', namespace,
+         '_gps_navsat/navsat'
+         '@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat'],
+        # Heading IMU
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace, '/heading/sensor/', namespace,
+         '_heading_imu/imu'
+         '@sensor_msgs/msg/Imu[gz.msgs.IMU'],
+        # POS MV NavSat → sensors/nav/position
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace, '/motion_sensor/sensor/', namespace,
+         '_posmv_navsat/navsat'
+         '@sensor_msgs/msg/NavSatFix[gz.msgs.NavSat'],
+        # POS MV IMU → sensors/nav/orientation
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace, '/motion_sensor/sensor/', namespace,
+         '_posmv_imu/imu'
+         '@sensor_msgs/msg/Imu[gz.msgs.IMU'],
+        # Lidar point cloud
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace, '/lidar/sensor/lidar_sensor/scan/points'
+         '@sensor_msgs/msg/PointCloud2[gz.msgs.PointCloudPacked'],
+        # Forward camera image
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace,
+         '/forward_camera/sensor/forward_camera_sensor/image'
+         '@sensor_msgs/msg/Image[gz.msgs.Image'],
+        # Forward camera info
+        ['/world/', world_name, '/model/', namespace,
+         '/link/', namespace,
+         '/forward_camera/sensor/forward_camera_sensor/camera_info'
+         '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
+        # Thruster command (ROS → Gz)
+        ['/', namespace, '/thrusters/main/thrust'
+         '@std_msgs/msg/Float64]gz.msgs.Double'],
+        # Steering command (ROS → Gz)
+        ['/', namespace, '/thrusters/main/pos'
+         '@std_msgs/msg/Float64]gz.msgs.Double'],
+        # MBES ram position command (ROS → Gz)
+        ['/', namespace, '/mbes/ram/pos'
+         '@std_msgs/msg/Float64]gz.msgs.Double'],
+    ]
+
+    # Add panoramic cameras (6 cameras, image + camera_info each)
+    for i in range(1, 7):
+        bridge_args.extend([
+            ['/world/', world_name, '/model/', namespace,
+             '/link/', namespace,
+             f'/pano_{i}/sensor/pano_{i}_sensor/image'
+             '@sensor_msgs/msg/Image[gz.msgs.Image'],
+            ['/world/', world_name, '/model/', namespace,
+             '/link/', namespace,
+             f'/pano_{i}/sensor/pano_{i}_sensor/camera_info'
+             '@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
+        ])
+
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=bridge_args,
+        remappings=[
+            # GPS
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace, '/gps/sensor/', namespace,
+              '_gps_navsat/navsat'],
+             [namespace, '/sensors/gps/fix']),
+            # Heading
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace, '/heading/sensor/', namespace,
+              '_heading_imu/imu'],
+             [namespace, '/sensors/heading/data']),
+            # POS MV NavSat → sensors/nav/position (matches ben_sim.yaml)
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace, '/motion_sensor/sensor/', namespace,
+              '_posmv_navsat/navsat'],
+             [namespace, '/sensors/nav/position']),
+            # POS MV IMU → sensors/nav/orientation (matches ben_sim.yaml)
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace, '/motion_sensor/sensor/', namespace,
+              '_posmv_imu/imu'],
+             [namespace, '/sensors/nav/orientation']),
+            # Lidar
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace,
+              '/lidar/sensor/lidar_sensor/scan/points'],
+             [namespace, '/sensors/lidar/points']),
+            # Forward camera
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace,
+              '/forward_camera/sensor/forward_camera_sensor/image'],
+             [namespace, '/sensors/cameras/forward_camera/image_raw']),
+            (['/world/', world_name, '/model/', namespace,
+              '/link/', namespace,
+              '/forward_camera/sensor/forward_camera_sensor/camera_info'],
+             [namespace, '/sensors/cameras/forward_camera/camera_info']),
+        ] + [
+            remap
+            for i in range(1, 7)
+            for remap in [
+                (['/world/', world_name, '/model/', namespace,
+                  '/link/', namespace,
+                  f'/pano_{i}/sensor/pano_{i}_sensor/image'],
+                 [namespace, f'/sensors/cameras/pano_{i}/image_raw']),
+                (['/world/', world_name, '/model/', namespace,
+                  '/link/', namespace,
+                  f'/pano_{i}/sensor/pano_{i}_sensor/camera_info'],
+                 [namespace, f'/sensors/cameras/pano_{i}/camera_info']),
+            ]
+        ],
+        parameters=[{'use_sim_time': True}],
+        output='screen',
+    )
+
+    return LaunchDescription([
+        declare_namespace,
+        declare_world_name,
+        declare_x, declare_y, declare_z,
+        declare_R, declare_P, declare_Y,
+        robot_state_publisher,
+        spawn_entity,
+        bridge,
+    ])

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,13 @@
   <depend>ben_description</depend>
   <depend>ros_gz_sim</depend>
   <depend>ros_gz_bridge</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>control_toolbox</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>marine_interfaces</depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/src/gazebo_helm_node.cpp
+++ b/src/gazebo_helm_node.cpp
@@ -122,7 +122,7 @@ private:
 
     if (have_odom_) {
       auto now = get_clock()->now();
-      auto odom_age = now - rclcpp::Time(latest_odom_.header.stamp);
+      auto odom_age = now - rclcpp::Time(latest_odom_.header.stamp, get_clock()->get_clock_type());
       if (odom_age.seconds() < 1.0) {
         double error = msg->twist.linear.x - latest_odom_.twist.twist.linear.x;
         rclcpp::Duration dt(0, 0);

--- a/src/gazebo_helm_node.cpp
+++ b/src/gazebo_helm_node.cpp
@@ -1,0 +1,227 @@
+// Gazebo helm node: converts Helm/cmd_vel commands to Gazebo thruster outputs.
+//
+// Replaces asv_helm for the Gazebo simulation path. Outputs thrust in Newtons
+// and steering deflection in radians (matching Gz thruster/joint plugins).
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <control_toolbox/pid_ros.hpp>
+
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <marine_interfaces/msg/helm.hpp>
+#include <marine_interfaces/msg/heartbeat.hpp>
+#include <marine_interfaces/msg/key_value.hpp>
+
+using CallbackReturn =
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class GazeboHelm : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  GazeboHelm(const rclcpp::NodeOptions & options)
+  : rclcpp_lifecycle::LifecycleNode("gazebo_helm", options)
+  {
+    // Declare parameters with defaults matching BEN's Gz model
+    declare_parameter("max_forward_thrust", 1800.0);
+    declare_parameter("max_reverse_thrust", 500.0);
+    declare_parameter("max_deflection", 0.524);  // ~30 degrees
+    declare_parameter("max_speed", 2.75);
+    declare_parameter("max_yaw_speed", 0.5);
+  }
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State &) override
+  {
+    max_forward_thrust_ = get_parameter("max_forward_thrust").as_double();
+    max_reverse_thrust_ = get_parameter("max_reverse_thrust").as_double();
+    max_deflection_ = get_parameter("max_deflection").as_double();
+    max_speed_ = get_parameter("max_speed").as_double();
+    max_yaw_speed_ = get_parameter("max_yaw_speed").as_double();
+
+    // Publishers — thrust in Newtons, pos in radians
+    thrust_pub_ = create_publisher<std_msgs::msg::Float64>(
+        "thrusters/main/thrust", 1);
+    pos_pub_ = create_publisher<std_msgs::msg::Float64>(
+        "thrusters/main/pos", 1);
+    heartbeat_pub_ = create_publisher<marine_interfaces::msg::Heartbeat>(
+        "marine/status/helm", 1);
+
+    // Subscribers
+    helm_sub_ = create_subscription<marine_interfaces::msg::Helm>(
+        "helm", 1,
+        [this](marine_interfaces::msg::Helm::ConstSharedPtr msg) {
+          helmCallback(msg);
+        });
+    twist_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+        "cmd_vel", 10,
+        [this](geometry_msgs::msg::TwistStamped::ConstSharedPtr msg) {
+          twistCallback(msg);
+        });
+    odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
+        "odom", 5,
+        [this](nav_msgs::msg::Odometry::ConstSharedPtr msg) {
+          latest_odom_ = *msg;
+          have_odom_ = true;
+        });
+
+    // Speed PID via control_toolbox
+    speed_pid_ = std::make_unique<control_toolbox::PidROS>(
+        get_node_base_interface(),
+        get_node_logging_interface(),
+        get_node_parameters_interface(),
+        get_node_topics_interface(),
+        "speed_pid.",
+        "speed_pid_state",
+        true);
+    speed_pid_->initialize_from_ros_parameters();
+
+    return CallbackReturn::SUCCESS;
+  }
+
+  CallbackReturn on_activate(const rclcpp_lifecycle::State &) override
+  {
+    return CallbackReturn::SUCCESS;
+  }
+
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State &) override
+  {
+    return CallbackReturn::SUCCESS;
+  }
+
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State &) override
+  {
+    thrust_pub_.reset();
+    pos_pub_.reset();
+    heartbeat_pub_.reset();
+    helm_sub_.reset();
+    twist_sub_.reset();
+    odom_sub_.reset();
+    speed_pid_.reset();
+    return CallbackReturn::SUCCESS;
+  }
+
+private:
+  void helmCallback(marine_interfaces::msg::Helm::ConstSharedPtr msg)
+  {
+    // Direct throttle/rudder → thrust/pos conversion
+    double throttle = std::clamp(static_cast<double>(msg->throttle), -1.0, 1.0);
+    double rudder = std::clamp(static_cast<double>(msg->rudder), -1.0, 1.0);
+    publishCommands(throttle, rudder);
+    publishHeartbeat();
+  }
+
+  void twistCallback(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+  {
+    double throttle;
+
+    if (have_odom_) {
+      auto now = get_clock()->now();
+      auto odom_age = now - rclcpp::Time(latest_odom_.header.stamp);
+      if (odom_age.seconds() < 1.0) {
+        double error = msg->twist.linear.x - latest_odom_.twist.twist.linear.x;
+        rclcpp::Duration dt(0, 0);
+        if (last_twist_time_.nanoseconds() > 0) {
+          dt = now - last_twist_time_;
+        }
+        last_twist_time_ = now;
+
+        if (dt.seconds() > 0.0 && dt.seconds() < 5.0) {
+          throttle = speed_pid_->compute_command(error, dt);
+          throttle = std::clamp(throttle, -1.0, 1.0);
+        } else {
+          throttle = msg->twist.linear.x / max_speed_;
+          speed_pid_->reset();
+        }
+      } else {
+        throttle = msg->twist.linear.x / max_speed_;
+      }
+    } else {
+      throttle = msg->twist.linear.x / max_speed_;
+    }
+
+    double rudder = -msg->twist.angular.z / max_yaw_speed_;
+    rudder = std::clamp(rudder, -1.0, 1.0);
+
+    // Minimum throttle for steering authority (same logic as asv_helm)
+    double min_throttle = 0.5 * std::abs(rudder);
+    if (msg->twist.linear.x > 0.0) {
+      throttle = std::max(throttle, min_throttle);
+    } else if (msg->twist.linear.x < 0.0) {
+      throttle = std::min(throttle, -min_throttle);
+    }
+
+    publishCommands(throttle, rudder);
+    publishHeartbeat();
+  }
+
+  void publishCommands(double throttle, double rudder)
+  {
+    std_msgs::msg::Float64 thrust_msg;
+    if (throttle >= 0.0) {
+      thrust_msg.data = throttle * max_forward_thrust_;
+    } else {
+      thrust_msg.data = throttle * max_reverse_thrust_;
+    }
+    thrust_pub_->publish(thrust_msg);
+
+    std_msgs::msg::Float64 pos_msg;
+    pos_msg.data = rudder * max_deflection_;
+    pos_pub_->publish(pos_msg);
+  }
+
+  void publishHeartbeat()
+  {
+    marine_interfaces::msg::Heartbeat hb;
+    hb.header.stamp = get_clock()->now();
+
+    marine_interfaces::msg::KeyValue kv;
+    kv.key = "sim";
+    kv.value = "gazebo";
+    hb.values.push_back(kv);
+
+    heartbeat_pub_->publish(hb);
+  }
+
+  // Parameters
+  double max_forward_thrust_{1800.0};
+  double max_reverse_thrust_{500.0};
+  double max_deflection_{0.524};
+  double max_speed_{2.75};
+  double max_yaw_speed_{0.5};
+
+  // Publishers
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr
+      thrust_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr
+      pos_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<marine_interfaces::msg::Heartbeat>::SharedPtr
+      heartbeat_pub_;
+
+  // Subscribers
+  rclcpp::Subscription<marine_interfaces::msg::Helm>::SharedPtr helm_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+
+  // PID
+  std::unique_ptr<control_toolbox::PidROS> speed_pid_;
+
+  // State
+  nav_msgs::msg::Odometry latest_odom_;
+  bool have_odom_{false};
+  rclcpp::Time last_twist_time_{0, 0, RCL_ROS_TIME};
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GazeboHelm>(rclcpp::NodeOptions());
+  rclcpp::spin(node->get_node_base_interface());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/gazebo_helm_node.cpp
+++ b/src/gazebo_helm_node.cpp
@@ -214,7 +214,7 @@ private:
   // State
   nav_msgs::msg::Odometry latest_odom_;
   bool have_odom_{false};
-  rclcpp::Time last_twist_time_{0, 0, RCL_ROS_TIME};
+  rclcpp::Time last_twist_time_;
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Summary

- Split `gazebo_launch.py` into reusable `spawn_ben_launch.py` + thin wrapper
- `spawn_ben_launch.py` accepts `world_name` parameter (default `'ocean'`) for bridge topic paths
- POS MV sensors remapped to `sensors/nav/*` convention matching `ben_sim.yaml`
- Add `gazebo_helm` C++ lifecycle node: converts Helm/cmd_vel to thrust (Newtons) and steering (radians) for Gz plugins
- Uses `control_toolbox::PidROS` for speed PID control

Closes #7
Part of rolker/unh_marine_simulation#25

## Test plan

- [ ] `ros2 launch ben_gazebo gazebo_launch.py` still works (backward compatible)
- [ ] `ros2 launch ben_gazebo spawn_ben_launch.py` can spawn BEN into external world
- [ ] `gazebo_helm` node builds and can be launched as lifecycle node
- [ ] Thruster topics receive correct values for helm commands

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
